### PR TITLE
updates for object detection pipeline

### DIFF
--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -664,14 +664,12 @@ func (a *stubAIWorker) TextToSpeech(ctx context.Context, req worker.GenTextToSpe
 }
 
 func (a *stubAIWorker) ObjectDetection(ctx context.Context, req worker.GenObjectDetectionMultipartRequestBody) (*worker.ObjectDetectionResponse, error) {
-	return &worker.ObjectDetectionResponse{Frames: [][]worker.Media{
-		{
-			{Url: "http://example.com/frames1.mp4", Nsfw: false},
-		},
-		{
-			{Url: "http://example.com/frames2.mp4", Nsfw: false},
-		},
-	}, ConfidenceScores: "confidence_scores", Labels: "labels", DetectionBoxes: "detection_boxes", FramesPts: "frames_pts"}, nil
+	return &worker.ObjectDetectionResponse{
+		Video:            {Url: "http://example.com/frames1.mp4"},
+		ConfidenceScores: "confidence_scores",
+		Labels:           "labels",
+		DetectionBoxes:   "detection_boxes",
+		DetectionPts:     "detection_pts"}, nil
 }
 
 func (a *stubAIWorker) Warm(ctx context.Context, arg1, arg2 string, endpoint worker.RunnerEndpoint, flags worker.OptimizationFlags) error {

--- a/server/ai_worker.go
+++ b/server/ai_worker.go
@@ -325,7 +325,7 @@ func runAIJob(n *core.LivepeerNode, orchAddr string, httpc *http.Client, notify 
 			break
 		}
 		modelID = *req.ModelId
-		resultType = "application/json"
+		resultType = "video/mp4"
 		req.Video.InitFromBytes(input, "video")
 		processFn = func(ctx context.Context) (interface{}, error) {
 			return n.ObjectDetection(ctx, req)


### PR DESCRIPTION
- updates to use updated response from ai-runner after changes in my PR to your object detection branch
- Add ObjectDetection to `saveLocalAIWorkerResults` and `saveRemoteAIWorkerResults` including only saving video to NodeStorage if it is included in the response.
- update the ObjectDetection path to return result from ai worker and not process the result.  The ai worker processes the base64 encoded video in `runAIJob` and sends back binary video as part of the response posted to `/aIResults` at the Orchestrator.
